### PR TITLE
fix: serialize function shouldn't mutate given argument.

### DIFF
--- a/app/store/sqlcipher-db-storage.js
+++ b/app/store/sqlcipher-db-storage.js
@@ -5,16 +5,47 @@ import CacheEngineBase from '../lib/peerio-icebear/db/cache-engine-base';
 sqlcipher.enablePromise(false);
 
 function serialize(item) {
+    if (
+        !item ||
+        typeof item !== "object" ||
+        Array.isArray(item) ||
+        typeof item === "number" ||
+        typeof item === Date
+    ) {
+        return JSON.stringify(item);
+    }
+
+    let copy;
+    function ensureCopy() {
+        if (copy === undefined) {
+            copy = {
+                ...item
+            };
+        }
+    }
+
     if (item.payload) {
-        item.payload = bytesToB64(item.payload);
+        ensureCopy();
+        copy.payload = bytesToB64(item.payload);
     }
     if (item.chatHead && item.chatHead.payload) {
-        item.chatHead.payload = bytesToB64(item.chatHead.payload);
+        ensureCopy();
+        copy.chatHead = {
+            ...item.chatHead,
+            payload: bytesToB64(item.chatHead.payload)
+        };
     }
     if (item.props && item.props.descriptor && item.props.descriptor.payload) {
-        item.props.descriptor.payload = bytesToB64(item.props.descriptor.payload);
+        ensureCopy();
+        copy.props = {
+            ...item.props,
+            descriptor: {
+                ...item.props.descriptor,
+                payload: bytesToB64(item.props.descriptor.payload)
+            }
+        };
     }
-    return JSON.stringify(item);
+    return JSON.stringify(copy || item);
 }
 
 function deserialize(data) {


### PR DESCRIPTION
#### Relevant info and issue/PR links 
IO functions shouldn't mutate given arguments. 
potential issue case: using writeItem second time with same argument.

```
const storage = new SqlCipherDbStorage()
const payload = generatePayload();

const item = {payload}
storage.setValue("key1", item)
.catch(anyError => {
    // I may want to retry this, but item is corrupted because of mutations in serialize function.
    const isPayloadSame = item.payload === payload
    console.log(isPayloadSame)
    // => false
})
```
#### Testing instructions  


----
### Repository owner

- [1] Was tested and can be merged.
- [1] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
